### PR TITLE
Increase width of artist dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - @testing-library/jest-dom
 
 ### Changed
+- Increase width of artist dialogs ([#120](../../issues/120)).
 - Downgrade dev dependencies:
   - eslint 5.3.0 
   - eslint-plugin-flowtype 3.9.1

--- a/src/components/artist/ArtistDialog.js
+++ b/src/components/artist/ArtistDialog.js
@@ -8,6 +8,7 @@ import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import TextField from "@material-ui/core/TextField";
+import { makeStyles } from "@material-ui/styles";
 
 import * as api from "../../api/types";
 import type { DialogType } from "../../redux/dialog/types";
@@ -31,6 +32,19 @@ type Props = {
   artist: api.Artist,
   token: ?string
 };
+
+const useStyles = makeStyles(theme => ({
+  paper: {
+    width: "auto",
+    marginLeft: theme.spacing(3),
+    marginRight: theme.spacing(3),
+    [theme.breakpoints.up(400 + theme.spacing(3 * 2))]: {
+      width: 400,
+      marginLeft: "auto",
+      marginRight: "auto"
+    }
+  }
+}));
 
 export const ArtistDialog = ({
   /* eslint-disable no-shadow */
@@ -59,9 +73,15 @@ export const ArtistDialog = ({
   };
 
   const title = type === DIALOG_TYPE_CREATE ? "Add" : "Update";
+  const classes = useStyles();
 
   return (
-    <Dialog data-testid="dialog" open={open} onClose={closeDialog}>
+    <Dialog
+      data-testid="dialog"
+      open={open}
+      onClose={closeDialog}
+      classes={classes}
+    >
       <DialogTitle>{title} artist</DialogTitle>
       <DialogContent>
         <TextField

--- a/src/components/artist/ArtistDialog.spec.js
+++ b/src/components/artist/ArtistDialog.spec.js
@@ -1,8 +1,9 @@
 // @flow
 import React from "react";
-import { render, fireEvent } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
 
 import { ArtistDialog } from "./ArtistDialog";
+import render from "../../utils/test/render";
 import { ARTIST, TOKEN } from "../../utils/test/fixtures";
 import {
   DIALOG_TYPE_CREATE,


### PR DESCRIPTION
Use a dialog width of `400px` with a margin of `24px` on both sides. On smaller
viewports, decrease the width to preserve the margin.

This is aligned with the styling for the `SignIn` and `SignUp` forms.

Closes #116 